### PR TITLE
Fix the issue with examples in pcp function

### DIFF
--- a/nbs/3. Background Removal with Robust PCA.ipynb
+++ b/nbs/3. Background Removal with Robust PCA.ipynb
@@ -1199,7 +1199,7 @@
     "        Z = X - L - S\n",
     "        Y += mu*Z; mu *= rho\n",
     "        \n",
-    "        examples.extend([S[140,:], L[140,:]])\n",
+    "        examples.extend([S[:,140], L[:,140]])\n",
     "        \n",
     "        if m > mu_bar: m = mu_bar\n",
     "        if converged(Z, d_norm): break\n",


### PR DESCRIPTION
This PR fix one issue with the PCP function in notebook of Background Removal with Robust PCA. 

- The examples array needs to get some random image of matrix S and L, therefore it should be examples.extend([S[:,140], L[:,140]]), where 140 is a random number. The original notebook is
examples.extend([S[140,:], L[140,:]]), which will generate error when calling plots() function.